### PR TITLE
Fix lint action

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ jobs:
     name: Linting
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Lint
         run: |


### PR DESCRIPTION
Using actions/checkoutv3 was failing, possibly due to deprecated Node.js v16.